### PR TITLE
Add requirements and basic notebook

### DIFF
--- a/JupyterBasics.ipynb
+++ b/JupyterBasics.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic info for a repo\n",
+    "\n",
+    "This notebook uses the github3py project maintained by Ian Cordasco.\n",
+    "\n",
+    "A starter notebook for finding information about a repository."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# import github3py project\n",
+    "import github3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Org and repo\n",
+    "item_org = 'jupyterhub'\n",
+    "item_repo = 'jupyterhub'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Get open issues for org and repo\n",
+    "print('Basics for {}/{}:'.format(item_org, item_repo))\n",
+    "\n",
+    "print(gh.repository(item_org, item_repo).clone_url)\n",
+    "print('Created: {}'.format(gh.repository(item_org, item_repo).created_at))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Get release tags for org and repo\n",
+    "print('Versions for {}/{}'.format(item_org, item_repo))\n",
+    "\n",
+    "for tag in gh.repository(item_org, item_repo).tags():\n",
+    "    print(str(tag))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Get open issues for org and repo\n",
+    "print('Number of open issues for {}/{}:'.format(item_org, item_repo))\n",
+    "\n",
+    "print(gh.repository(item_org, item_repo).open_issues_count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Get dictionary for org and repo\n",
+    "print('Dictionary for {}/{}:'.format(item_org, item_repo))\n",
+    "\n",
+    "gh.repository(item_org, item_repo).as_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+jupyter
+pandas
+github3.py


### PR DESCRIPTION
Add a notebook to use github3py for a few simple tasks that do not require authentication to the GitHub API.

Add requirements for development.
